### PR TITLE
Changed the url_prefix to rewrite the handlers regex patterns.

### DIFF
--- a/flower/views/__init__.py
+++ b/flower/views/__init__.py
@@ -95,8 +95,3 @@ class BaseHandler(tornado.web.RequestHandler):
     def capp(self):
         "return Celery application object"
         return self.application.capp
-
-    def reverse_url(self, *args):
-        prefix = self.application.options.url_prefix
-        url = super(BaseHandler, self).reverse_url(*args)
-        return prepend_url(url, prefix) if prefix else url

--- a/tests/unit/views/test_url_handlers.py
+++ b/tests/unit/views/test_url_handlers.py
@@ -1,0 +1,58 @@
+from tests.unit import AsyncHTTPTestCase
+from flower.app import rewrite_handler
+from tornado.web import url
+
+
+class UrlsTests(AsyncHTTPTestCase):
+    def test_dashboard_url(self):
+        r = self.get('/dashboard')
+        self.assertEqual(200, r.code)
+
+    def test_root_url(self):
+        r = self.get('/')
+        self.assertEqual(200, r.code)
+
+    def test_tasks_api_url(self):
+        r = self.get('/api/tasks')
+        self.assertEqual(200, r.code)
+
+
+class URLPrefixTests(AsyncHTTPTestCase):
+    def setUp(self):
+        with self.mock_option('url_prefix', 'test_root'):
+            super(URLPrefixTests, self).setUp()
+
+    def test_tuple_handler_rewrite(self):
+        r = self.get('/test_root/dashboard')
+        self.assertEqual(200, r.code)
+
+    def test_root_url(self):
+        r = self.get('/test_root/')
+        self.assertEqual(200, r.code)
+
+    def test_tasks_api_url(self):
+        r = self.get('/test_root/api/tasks')
+        self.assertEqual(200, r.code)
+
+    def test_base_url_no_longer_working(self):
+        r = self.get('/dashboard')
+        self.assertNotEqual(200, r.code)
+
+
+class RewriteHandlerTests(AsyncHTTPTestCase):
+    def target(self):
+        return None
+
+    def test_url_rewrite_using_URLSpec(self):
+        old_handler = url(r"/", self.target, name='test')
+        new_handler = rewrite_handler(old_handler, 'test_root')
+        self.assertIsInstance(new_handler, url)
+        self.assertTrue(new_handler.regex.match('/test_root/'))
+        self.assertFalse(new_handler.regex.match('/'))
+        self.assertFalse(new_handler.regex.match('/'))
+
+    def test_url_rewrite_using_tuple(self):
+        old_handler = (r"/", self.target)
+        new_handler = rewrite_handler(old_handler, 'test_root')
+        self.assertIsInstance(new_handler, tuple)
+        self.assertEqual(new_handler[0], '/test_root/')


### PR DESCRIPTION
Applying PR https://github.com/mher/flower/pull/766 from @scrummyin to this fork.

> This will cause nginx to no longer be needed to run in front of flower when adding a url_prefix. A side effect will be that we no longer need to prefix urls when we write them to the templates as the handlers will reflect that change.