### PR TITLE
Change default sorting to 'desc' to see most recent first

### DIFF
--- a/flower/static/js/flower.js
+++ b/flower/static/js/flower.js
@@ -729,7 +729,7 @@ var flower = (function () {
                 url: url_prefix() + '/tasks/datatable'
             },
             order: [
-                [7, "asc"]
+                [7, "desc"]
             ],
             oSearch: {
                 "sSearch": $.urlParam('state') ? 'state:' + $.urlParam('state') : ''


### PR DESCRIPTION
I'd prefer to see the most recent jobs first on the list.